### PR TITLE
perf: Show cumulative overheads for second version in compare_builds.R

### DIFF
--- a/perftest/compare_builds.R
+++ b/perftest/compare_builds.R
@@ -53,3 +53,11 @@ totals <- data.frame(t((100 * (colSums(bt2[, start_col:end_col], na.rm = TRUE) -
 row.names(totals) <- c(" Sum. incr.:")
 message("")
 print(totals)
+
+print(paste("Total real time with firebuild (%) in", args[2], ":"))
+vanilla <- sum(bt1[, 1], na.rm = TRUE)
+first <- sum(bt1[, 4], na.rm = TRUE)
+second <- sum(bt1[, 7], na.rm = TRUE)
+overheads <- c(first, second) / vanilla * 100
+names(overheads) <- c("first run", "second run")
+print(overheads)


### PR DESCRIPTION
The overheads are calculated comparing the instrumented builds' time
to the vanilla builds' time.

```
$ ./compare_builds.R buildtimes.csv v0.1-123-g7cd040a v0.1-128-gd4ee742
[1] "Versions have different run counts, cutting last runs from the shorter set: v0.1-128-gd4ee742 using only the first 109 runs"
Time % increase in v0.1-128-gd4ee742 vs. v0.1-123-g7cd040a

     real1              user1               sys1        
 Min.   :-21.1325   Min.   :-19.0628   Min.   :-50.400  
 1st Qu.: -9.3718   1st Qu.: -7.1942   1st Qu.:-27.542  
 Median : -5.5507   Median : -4.0075   Median :-15.583  
 Mean   : -6.9910   Mean   : -5.4378   Mean   :-18.133  
 3rd Qu.: -2.9787   3rd Qu.: -1.9987   3rd Qu.: -9.545  
 Max.   : -0.6007   Max.   :  0.7694   Max.   :  7.729  

                 real1     user1      sys1
 Sum. incr.: -6.163566 -4.367598 -15.48493

     real2              user2               sys2       
 Min.   :-19.0553   Min.   :-16.2449   Min.   :-38.11  
 1st Qu.:-10.7561   1st Qu.: -7.6494   1st Qu.:-25.76  
 Median : -5.9937   Median : -4.8073   Median :-17.66  
 Mean   : -7.2715   Mean   : -5.4344   Mean   :-17.18  
 3rd Qu.: -3.6241   3rd Qu.: -2.5620   3rd Qu.:-10.96  
 Max.   :  0.3246   Max.   :  0.5565   Max.   : 51.92  

                 real2     user2      sys2
 Sum. incr.: -6.145009 -4.669397 -14.17899

     real3             user3             sys3       
 Min.   :-38.491   Min.   :-64.29   Min.   :-75.00  
 1st Qu.:-25.140   1st Qu.:-21.91   1st Qu.:-34.74  
 Median :-18.225   Median :-14.61   Median :-26.50  
 Mean   :-17.772   Mean   :-15.29   Mean   :-25.36  
 3rd Qu.: -9.115   3rd Qu.: -6.45   3rd Qu.:-14.78  
 Max.   : -2.316   Max.   : 14.29   Max.   : 27.27  

                 real3     user3      sys3
 Sum. incr.: -8.846627 -6.595326 -18.38442

Cache size % increase in v0.1-128-gd4ee742 vs. v0.1-123-g7cd040a
  cache.size.1      cache.size.2    
 Min.   :-0.3568   Min.   :-0.3568  
 1st Qu.:-0.0124   1st Qu.:-0.0127  
 Median : 0.0000   Median : 0.0000  
 Mean   : 0.0380   Mean   : 0.1123  
 3rd Qu.: 0.0000   3rd Qu.: 0.0000  
 Max.   : 3.8610   Max.   : 7.3460  

             cache.size.1 cache.size.2
 Sum. incr.:   0.08944997    0.1774596

Total time with firebuild (%) in v0.1-128-gd4ee742 :
         first run second run
real      106.3447   27.99944
user      104.5567   25.85057
sys       156.4746   45.46387
user+sys  109.6594   27.77826

```
