### PR TITLE
perftest: Don't use ppa:rbalint/hopscotch-map

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -20,7 +20,7 @@ echo " · Adding deb-src entries to sources.list"
 lxc exec firebuild-perftest-image-template -- sh -c 'sed "s/^deb /deb-src /" < /etc/apt/sources.list > /etc/apt/sources.list.d/deb-src.list'
 
 echo " . Adding PPAs for backported and fixed packages"
-for ppa in ppa:rbalint/fmtlib ppa:rbalint/hopscotch-map ppa:rbalint/xxhash; do
+for ppa in ppa:rbalint/fmtlib ppa:rbalint/xxhash; do
     lxc exec firebuild-perftest-image-template -- add-apt-repository -y -n $ppa
 done
 lxc exec firebuild-perftest-image-template -- apt-get update -qq


### PR DESCRIPTION
Hopscotch-map's suspected bug seems to be in GCC 9, fixed (or not triggered) in GCC 10.