### PR TITLE
distro-rebuild: Add Makefile to generate list of Ubuntu 20.04 main's packages

### DIFF
--- a/distro-rebuilds/ubuntu-focal/Makefile
+++ b/distro-rebuilds/ubuntu-focal/Makefile
@@ -1,0 +1,9 @@
+main-pkgs:
+	chdist -d chdist-dir create focal http://archive.ubuntu.com/ubuntu focal main ; \
+	chdist -d chdist-dir apt focal update && \
+	awk '/^Package: / {print $$2}' chdist-dir/*/var/lib/apt/lists/*_source_Sources > $@
+
+clean:
+	rm -rf chdist-dir main-pkgs
+
+.PHONY: clean


### PR DESCRIPTION
This is not generic enough yet to be reused for other releases,
just documents and scripts the practice.