### PR TITLE
perftest: Skip parallel build test for some more packages

### DIFF
--- a/perftest/outer
+++ b/perftest/outer
@@ -216,7 +216,9 @@ for test in tests_to_run:
     test_type = None
 
   skip_parallel = ["blt",       # https://bugs.debian.org/1003455
-                   "dict-ns",   # All dict-* packages are compat 5
+                   "dict-af",   # Most dict-?? packages are compat 5
+                   "dict-nr",
+                   "dict-ns",
                    "dict-ss",
                    "dict-st",
                    "dict-tn",


### PR DESCRIPTION
Note: `dict-wn` has a higher compat level, it's some `wordnet` stuff, whatever that means, `wn` is not a language code.

There are also about 150 other packages with longer `dict-*` names, mostly `dict-freedict-???-???` between two languages.

Therefore the comment was inaccurate. Also, `dict-nr` failed in your last build.