### PR TITLE
distro-rebuilds: Skip Go related source packages

### DIFF
--- a/distro-rebuilds/ubuntu-focal/Makefile
+++ b/distro-rebuilds/ubuntu-focal/Makefile
@@ -1,6 +1,6 @@
 
 main-pkgs-filtered: main-pkgs
-	grep -v '^linux' $<  > $@
+	egrep -v '(^linux|golang)' $<  > $@
 
 main-pkgs:
 	chdist -d chdist-dir create focal http://archive.ubuntu.com/ubuntu focal main ; \


### PR DESCRIPTION
Go has its own build caching framework