### PR TITLE
perftest: Don't test gnome-terminal's parallel build

### DIFF
--- a/perftest/outer
+++ b/perftest/outer
@@ -249,9 +249,10 @@ for test in tests_to_run:
                    "dict-xh",
                    "dict-zu",
                    "fbset",
+                   "gnome-terminal",  # https://github.com/rbalint/fb/issues/739
                    "nss",
                    "nvidia-settings"]
-  if test_type == "deb" and int(args.jobs) != 1 and name in skip_parallel:
+  if int(args.jobs) != 1 and name in skip_parallel:
     debug("Skipping " + name + " because it does not support parallel building")
     continue
 


### PR DESCRIPTION
It generates the same file in parallel builds and this is not supported by firebuild yet.

Also allow skipping parallel builds for tests in tests.conf
(and in custom test configuration files).