### PR TITLE
perftest: Add build-essential, node-d3 and graphviz to base image

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -80,8 +80,8 @@ lxc exec firebuild-perftest-image-template -- eatmydata apt-get -yqq purge snapd
 echo " · Disabling APT updates"
 lxc exec firebuild-perftest-image-template -- bash -c 'sed -i s/1/0/ /etc/apt/apt.conf.d/10periodic 2> /dev/null || true'
 
-echo " · Installing needed packages"
-lxc exec firebuild-perftest-image-template -- eatmydata apt-get install -qqy git python3
+echo " · Installing needed and most likely needed packages"
+lxc exec firebuild-perftest-image-template -- eatmydata apt-get install -qqy git python3 node-d3 graphviz build-essential
 
 if $WITH_DIFFOSCOPE; then
     lxc exec firebuild-perftest-image-template -- eatmydata apt-get install -qqy fakeroot diffoscope


### PR DESCRIPTION
Build-essential is required by all Debian package builds,
node-d3 and graphviz are needed by firebuild.