### PR TITLE
perftest: fmt is no longer used

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -48,7 +48,7 @@ fi
 
 case $BASE_IMG in
     ubuntu*:focal)
-        PPAS="ppa:rbalint/fmtlib ppa:rbalint/xxhash"
+        PPAS="ppa:rbalint/xxhash"
         ;;
     ubuntu*:impish)
         PPAS="ppa:rbalint/xxhash"


### PR DESCRIPTION
Depends on the corresponding PR of the main repo.