### PR TITLE
perftest: Allow setting extra firebuild options for 1st and 2nd intercepted builds

### DIFF
--- a/perftest/inner
+++ b/perftest/inner
@@ -56,6 +56,10 @@ parser.add_argument("--with-ccache",
 parser.add_argument("--only-ccache",
                     action="store_true",
                     help="Use ccache instead of firebuild")
+parser.add_argument("--extra-fb-opts1",
+                    help="Extra firebuild options for the 1st intercepted build. Use the --extra-fb-opts1=\"...\" notation.")
+parser.add_argument("--extra-fb-opts2",
+                    help="Extra firebuild options for the 2nd intercepted build. Use the --extra-fb-opts2=\"...\" notation.")
 parser.add_argument("--tests-conf",
                     default="tests.conf",
                     help="configuration file with test descriptions")
@@ -263,8 +267,10 @@ def build_project(name, params):
       os.system("touch /tmp/firebuild_started")
       if not args.only_ccache:
         os.system("firebuild --version")
-      firebuild_params = "-r/tmp/report-1.html" if args.generate_report else ""
-      firebuil_cmd = "firebuild {} -- ".format(firebuild_params) if not args.only_ccache else ""
+      firebuild_params = " -r/tmp/report-1.html" if args.generate_report else ""
+      if args.extra_fb_opts1:
+        firebuild_params += " " + args.extra_fb_opts1
+      firebuil_cmd = "firebuild{} -- ".format(firebuild_params) if not args.only_ccache else ""
       (status, times1) = run_build_cmd("{} {}{}".format(env_cmd, firebuil_cmd, cmd), timeout_minutes * timeout_multiplier)
       if status == 0 and args.with_diffoscope:
         build_debs(srcdir)
@@ -277,8 +283,10 @@ def build_project(name, params):
     if status == 0:
       restore_saved_tree(name, srcdir)
       debug("Building «{}» with {}, from cache".format(name, build_tool))
-      firebuild_params = "-r/tmp/report-2.html" if args.generate_report else ""
-      firebuil_cmd = "firebuild {} -- ".format(firebuild_params) if not args.only_ccache else ""
+      firebuild_params = " -r/tmp/report-2.html" if args.generate_report else ""
+      if args.extra_fb_opts2:
+        firebuild_params += " " + args.extra_fb_opts2
+      firebuil_cmd = "firebuild{} -- ".format(firebuild_params) if not args.only_ccache else ""
       (status, times2) = run_build_cmd("{} {}{}".format(env_cmd, firebuil_cmd, cmd), timeout_minutes * timeout_multiplier)
       if status == 0 and args.with_diffoscope:
         build_debs(srcdir)

--- a/perftest/outer
+++ b/perftest/outer
@@ -74,6 +74,10 @@ parser.add_argument("--with-ccache",
 parser.add_argument("--only-ccache",
                     action="store_true",
                     help="Install and use ccache instead of firebuild")
+parser.add_argument("--extra-fb-opts1",
+                    help="Extra firebuild options for the 1st intercepted build. Use the --extra-fb-opts1=\"...\" notation.")
+parser.add_argument("--extra-fb-opts2",
+                    help="Extra firebuild options for the 2nd intercepted build. Use the --extra-fb-opts2=\"...\" notation.")
 parser.add_argument("--tests-conf",
                     default="tests.conf",
                     help="configuration file with test descriptions")
@@ -283,6 +287,8 @@ for test in tests_to_run:
                      ("--generate-report " if args.generate_report else "") +
                      ("--with-ccache " if args.with_ccache else "") +
                      ("--only-ccache " if args.only_ccache else "") +
+                     ("--extra-fb-opts1=\"{}\" ".format(args.extra_fb_opts1) if args.extra_fb_opts1 else "") +
+                     ("--extra-fb-opts2=\"{}\" ".format(args.extra_fb_opts2) if args.extra_fb_opts2 else "") +
                      ("--tests-conf {} ".format(args.tests_conf) if args.tests_conf else "") +
                      name + ((":" + test_type + ":" + timeout) if test_type is not None else "") +"' " + scriptfile)
   status = shell_exit_status(status)


### PR DESCRIPTION
I've added extra debug options to analyze caching/shortcutting a few times and this is just easier.