### PR TITLE
perftest: Don't repeat short tests

### DIFF
--- a/perftest/tests.conf
+++ b/perftest/tests.conf
@@ -45,8 +45,6 @@
     "type": "deb",
     "prep": "dh_autoreconf && ./configure",
     "cmd": "make -j{NR}",
-    # This is a quickly compiling package, compile 5 times for more accurate numbers.
-    "repeat": 5,
     "timeout_minutes": 2,
   },
   "bzip2": {
@@ -92,8 +90,6 @@
     "type": "deb",
     "prep": "./configure",
     "cmd": "make -j{NR}",
-    # This is a quickly compiling package, compile 5 times for more accurate numbers.
-    "repeat": 5,
     "timeout_minutes": 2,
   },
   "ltrace": {
@@ -185,8 +181,6 @@
     "type": "deb",
     "prep": "meson build",
     "cmd": "ninja -Cbuild -j{NR}",
-    # This is a relatively quickly compiling package, compile 5 times for more accurate numbers.
-    "repeat": 5,
     "timeout_minutes": 5,
   },
 
@@ -275,8 +269,6 @@
   },
   "jumpnbump": {
     "type": "deb",
-    # This is a quickly compiling package, compile 5 times for more accurate numbers.
-    "repeat": 5,
     "timeout_minutes": 1,
   },
   "xblast-tnt": {


### PR DESCRIPTION
This overrepresents short builds including their configuration phase which are
not the primary target for acceleration and firebuild does not accelerate them
well.