### PR TITLE
perftest: Use default prep and build commands for file and util-linux

### DIFF
--- a/perftest/tests.conf
+++ b/perftest/tests.conf
@@ -70,8 +70,6 @@
   },
   "file": {
     "type": "deb",
-    "prep": "./configure",
-    "cmd": "make -j{NR}",
     "timeout_minutes": 5,
   },
   "grep": {
@@ -159,8 +157,6 @@
   },
   "util-linux": {
     "type": "deb",
-    "prep": "./configure",
-    "cmd": "make -j{NR}",
     "timeout_minutes": 10,
   },
   "xz-utils": {


### PR DESCRIPTION
The custom ones failed on Ubuntu 22.04.