### PR TITLE
perftest: Fix prep command for openssh, nginx and coreutils

### DIFF
--- a/perftest/tests.conf
+++ b/perftest/tests.conf
@@ -54,6 +54,7 @@
   },
   "coreutils": {
     "type": "deb",
+    "prep": "dh_autoreconf && make -f debian/rules override_dh_auto_configure",
     "timeout_minutes": 10,
   },
   "diffutils": {
@@ -249,10 +250,14 @@
   },
   "nginx": {
     "type": "deb",
+    # Don't do anything for prep, override_dh_auto_configure applies patches and it gets messy
+    "prep": "true",
     "timeout_minutes": 30,
   },
   "openssh": {
     "type": "deb",
+    # debian/rules does not define override_dh_autoreconf target, just those:
+    "prep": "make -j1 -f debian/rules override_dh_autoreconf-arch override_dh_auto_configure-arch",
     "timeout_minutes": 10,
   },
   "openssl": {


### PR DESCRIPTION
Those fail with `./outer --separate-deb-prep`.