### PR TITLE
perftest: Skip parallel testing gcc-10

### DIFF
--- a/perftest/outer
+++ b/perftest/outer
@@ -271,6 +271,7 @@ for test in tests_to_run:
                    "dict-xh",
                    "dict-zu",
                    "fbset",
+                   "gcc-10",    # Racy https://github.com/rbalint/fb/issues/905
                    "ispell-uk",  # Does not support parallel build, compat 7
                    "lua5.2",    # Racy src/Makefile https://github.com/rbalint/fb/issues/840
                    "lua5.3",


### PR DESCRIPTION
It is racy without firebuild, too.