### PR TITLE
perftest: Always include phased package updates

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -40,6 +40,9 @@ if [ -n "$(apt-config dump | grep Proxy)" ]; then
     apt-config dump | grep Proxy | lxc exec firebuild-perftest-image-template -- sh -c 'cat > /etc/apt/apt.conf.d/99-firebuild-apt-proxy'
 fi
 
+# Always install phased updates to fix occasional uninstallability problems, like:
+# https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1979579
+echo 'APT::Get::Always-Include-Phased-Updates "true";' | lxc exec firebuild-perftest-image-template -- sh -c 'cat > /etc/apt/apt.conf.d/99-firebuild-phased-updates'
 
 if lxc exec firebuild-perftest-image-template -- sh -c 'dpkg -l needrestart 2> /dev/null | grep -q "^i"'; then
     echo " · Removing needrestart"


### PR DESCRIPTION
This prevents occasional uninstallability problems on Ubuntu.

Fixes #83.

This change is not testable at the moment because the phasing affecting multiple packages ended.