### PR TITLE
perftest: Sleep 1 sec only for Ubuntu 20.04 (Focal)'s startup in create_template_image

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -30,7 +30,15 @@ echo " · Launching lxc instance"
 lxc launch -p firebuild-perftest "$BASE_IMG" firebuild-perftest-image-template
 
 echo " · Waiting for system to start"
-sleep 0.5
+case $BASE_IMG in
+    ubuntu*:focal)
+        sleep 1
+        ;;
+    *)
+        # No sleep needed
+        ;;
+esac
+
 lxc exec firebuild-perftest-image-template -- systemctl is-system-running --wait || true
 
 echo " · Adding deb-src entries to sources.list"


### PR DESCRIPTION
Somehow Ubuntu 20.04 is slower to start.