### PR TITLE
Revert "perftest: Use ppa:rbalint/hopscotch-map again"

### DIFF
--- a/perftest/create_template_image
+++ b/perftest/create_template_image
@@ -59,10 +59,10 @@ fi
 
 case $BASE_IMG in
     ubuntu*:focal)
-        PPAS="ppa:rbalint/hopscotch-map ppa:rbalint/xxhash"
+        PPAS="ppa:rbalint/xxhash"
         ;;
     *)
-        PPAS="ppa:rbalint/hopscotch-map"
+        PPAS=""
 esac
 
 if [ -n "$PPAS" ]; then


### PR DESCRIPTION
It seems the bug was in Firebuild, and is now fixed.

This reverts commit 274adc1b01c7c42275286a5ea46bc888fc9ec1d7.