### PR TITLE
perftest: Add libjsr166y-java to default tests

### DIFF
--- a/perftest/tests.conf
+++ b/perftest/tests.conf
@@ -270,4 +270,9 @@
     "type": "deb",
     "timeout_minutes": 10,
   },
+  # uses javac and javadoc
+  "libjsr166y-java": {
+    "type": "deb",
+    "timeout_minutes": 5,
+  },
 }


### PR DESCRIPTION
This project uses javac and javadoc, both are accelerated.