### PR TITLE
perftest: Check ccache's cache size on the new path

### DIFF
--- a/perftest/inner
+++ b/perftest/inner
@@ -220,7 +220,7 @@ def build_project(name, params):
   dldir = builddir + "/" + name   # e.g. /home/ubuntu/perftest-build/mc
   srcdir = dldir + "/" + dirname  # e.g. /home/ubuntu/perftest-build/mc/mc-4.8.24
   fbcachedir = dldir + "/" + ".fbcache"
-  ccachedir = os.path.expanduser("~/.ccache")
+  ccachedir = os.path.expanduser("~/.cache/ccache")
   os.environ["FIREBUILD_CACHE_DIR"] = fbcachedir
   timeout_minutes = params["timeout_minutes"]
 


### PR DESCRIPTION
This is the default path of ccache 4.5.1 present in Ubuntu 22.04, which
is the default test target now.