### PR TITLE
perftest: Build the firebuild package with the default optimization level (-O2)

### DIFF
--- a/perftest/outer
+++ b/perftest/outer
@@ -108,8 +108,8 @@ def debug(str):
 
 def deb_build_env(debug_build):
   cppflags = "-DFB_EXTRA_DEBUG" if debug_build else ""
-  cflags = "-O0 -ggdb" if debug_build else "-O3"
-  cxxflags = "-O0 -ggdb" if debug_build else "-O3"
+  cflags = "-O0 -ggdb" if debug_build else ""
+  cxxflags = "-O0 -ggdb" if debug_build else ""
 
   return "DEB_CPPFLAGS_APPEND=\"{}\" DEB_CFLAGS_APPEND=\"{}\" DEB_CXXFLAGS_APPEND=\"{}\"".format(
     cppflags, cflags, cxxflags)


### PR DESCRIPTION
instead of overriding it with -O3.