### PR TITLE
perftest: Fix firefox test to really build firefox

### DIFF
--- a/perftest/tests-long.conf
+++ b/perftest/tests-long.conf
@@ -22,6 +22,9 @@
 {
  "firefox": {
    "type": "deb",
+   # Ubuntu archive's firefox package just pulls in the snap,
+   "dl": "sudo add-apt-repository -s -y ppa:mozillateam/ppa && apt-cache showsrc firefox | grep ^Version: | grep -v snap | head -n1 | sed s/Version:./firefox=/ | xargs apt-get source && mv firefox-* firefox && sudo apt-get  build-dep -y ./firefox",
+   "dir": "firefox",
    "timeout_minutes": 180,
  },
  "linux": {


### PR DESCRIPTION
, not just the snap installer package. Ubuntu ships Firefox as a snap since 22.04 and building the small snap installer package is useless as a test for firebuild.