### PR TITLE
perftest: Fix parsing non-git firebuild version

### DIFF
--- a/perftest/inner
+++ b/perftest/inner
@@ -250,7 +250,7 @@ def write_csv_row(start_timestamp, os_codename, name, cmd, status, times0, times
   build_tool_version = ""
   build_tool_timestamp = ""
   if not args.only_ccache:
-    build_tool_version  = os.popen("firebuild --version | awk '/Firebuild Git / {print $3}'").read().strip()
+    build_tool_version  = os.popen("firebuild --version | awk '/^Firebuild Git / {print $3}; /^Firebuild / {print $2}'").read().strip()
     build_tool_timestamp = os.popen("date -d \"$(dpkg-parsechangelog -l /usr/share/doc/firebuild/changelog.gz -S Date)\" +%s").read().strip()
   else:
     build_tool_timestamp = os.popen("date -d \"$(dpkg-parsechangelog -l /usr/share/doc/ccache/changelog.Debian.gz -S Date)\" +%s").read().strip()


### PR DESCRIPTION
For tagged releases `--version` is shown as:
```
Firebuild 0.2.11
...
```
