### PR TITLE
perftest: Optionally measure the tar'd zstd compressed size of the cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,5 @@ jobs:
         perftest/compare_builds.R ~/buildtimes.csv $(cut -d, -f3 ~/buildtimes.csv | tac)
     - name: option combinations
       run: |
-        sudo -u $USER env -C perftest ./outer -d -j3 --keep-log --stop-on-first-failure --sanitize -r --extra-version-string "options-test" --extra-fb-opts2='-d time' --timestamp-params="-i %.S" --enable-tests --separate-deb-prep -f ../firebuild json4s --tests-conf=tests.conf
+        sudo -u $USER env -C perftest ./outer -d -j3 --keep-log --stop-on-first-failure --sanitize -r --extra-version-string "options-test" --extra-fb-opts2='-d time' --compressed-cache-size --timestamp-params="-i %.S" --enable-tests --separate-deb-prep -f ../firebuild json4s --tests-conf=tests.conf
 

--- a/perftest/inner
+++ b/perftest/inner
@@ -88,6 +88,9 @@ parser.add_argument("--enable-tests",
 parser.add_argument("--separate-deb-prep",
                     help="Try a heuristic to run the configuration phase before measuring the \"deb\" type builds",
                     action="store_true")
+parser.add_argument("--compressed-cache-size",
+                    action="store_true",
+                    help="Measure cache's zstd-compressed size.")
 parser.add_argument("--timestamp-params",
                     help="Pipe build log through 'ts < timestamp-params >'")
 parser.add_argument("--tests-conf",
@@ -190,9 +193,12 @@ def prep_tree(name, srcdir, prep):
 
 
 # Get disk usage, in kilobytes, or 0 if the directory doesn't exist
-def get_du(dir):
-  ret = os.popen("du -s " + dir + " 2>/dev/null | cut -f1").read().strip()
-  return int(ret or "0")
+def get_du(path):
+  if args.compressed_cache_size:
+    du_cmd = "tar -cf - " + path + " 2> /dev/null | zstd | wc -c"
+  else:
+    du_cmd = "du -s " + path + " 2>/dev/null | cut -f1"
+  return int(os.popen(du_cmd).read().strip()  or "0") // 1024
 
 
 def build_debs(srcdir):

--- a/perftest/outer
+++ b/perftest/outer
@@ -103,6 +103,9 @@ parser.add_argument("--extra-fb-opts2",
                     help="Extra firebuild options for the 2nd intercepted build. Use the --extra-fb-opts2=\"...\" notation.")
 parser.add_argument("--extra-version-string",
                     help="Append \"-\" and this string to the version, like vN.N-NNN-gXXXXX-<extra version string>.")
+parser.add_argument("--compressed-cache-size",
+                    action="store_true",
+                    help="Measure cache's zstd-compressed size.")
 parser.add_argument("--timestamp-params",
                     help="Pipe build log through 'ts < timestamp-params >'")
 parser.add_argument("--enable-tests",
@@ -354,6 +357,7 @@ for test in tests_to_run:
                      ("--extra-fb-opts1=\"{}\" ".format(args.extra_fb_opts1) if args.extra_fb_opts1 else "") +
                      ("--extra-fb-opts2=\"{}\" ".format(args.extra_fb_opts2) if args.extra_fb_opts2 else "") +
                      ("--extra-version-string=\"{}\" ".format(args.extra_version_string) if args.extra_version_string else "") +
+                     ("--compressed-cache-size " if args.compressed_cache_size else "") +
                      ("--timestamp-params=\"{}\" ".format(args.timestamp_params) if args.timestamp_params else "") +
                      ("--enable-tests " if args.enable_tests else "") +
                      ("--separate-deb-prep " if args.separate_deb_prep else "") +


### PR DESCRIPTION
In (GitHub) CI the cache is typically saved as a tarball and extracted prior the builds. In that use case the tar'd size represents the cost of storing the cache better.

Fixes #94.