### PR TITLE
outer: Limit number of CPUs for the test container

### DIFF
--- a/perftest/outer
+++ b/perftest/outer
@@ -342,6 +342,12 @@ for test in tests_to_run:
   if (args.with_ccache or args.only_ccache) and args.ccache_is_sccache:
     os.system("lxc exec --user 1000 --group 1000 --cwd /home/ubuntu/ " + container_name + " -- cargo install sccache")
 
+  # Limit CPU usage.
+  # TODO(rbalint) work with 1,3,4... jobs format
+  if len(args.jobs.split(",")) == 1 and args.jobs != str(os.cpu_count()):
+    # Pin jobs to cores for consistent performance
+    os.system("lxc config set {} limits.cpu 0-{}".format(container_name, int(args.jobs) - 1))
+
   # Run the test
   debug("Running test «" + name + "»")
   status = os.system("script -e -c 'lxc exec --user 1000 --group 1000 --cwd /home/ubuntu/fb-infra/perftest " +


### PR DESCRIPTION
This helps getting realistic results for running builds on fewer CPUs when the build does not fully honor the -jX parameter.