### PR TITLE
perftest: Use Rust toolchain provided by rustup to build librsvg

### DIFF
--- a/perftest/tests.conf
+++ b/perftest/tests.conf
@@ -308,8 +308,8 @@
    "type": "deb+git",
    "dl": "git clone --shallow-since='Mar 15 19:45:07 2023 +0100' https://github.com/GNOME/librsvg.git",
    "dir": "librsvg",
-   "prep": "bash -c 'git checkout 2.56.0 && export PATH=$(ls -d /usr/lib/*/gdk-pixbuf-2.0):$PATH && ./autogen.sh'",
-   "cmd": "bash -c 'export PATH=$(ls -d /usr/lib/*/gdk-pixbuf-2.0):$PATH && make -j{NR}'",
+   "prep": "bash -c 'sudo apt-get -y remove rustc && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && git checkout 2.56.0 && export PATH=$(ls -d /usr/lib/*/gdk-pixbuf-2.0):$PATH && . $HOME/.cargo/env && ./autogen.sh'",
+   "cmd": "bash -c '. $HOME/.cargo/env && export PATH=$(ls -d /usr/lib/*/gdk-pixbuf-2.0):$PATH && make -j{NR}'",
    # crates outside of the build tree are updated in the first build, we should not measure that
    "warmup_vanilla_build": True,
    "timeout_minutes": 5,


### PR DESCRIPTION
This lets us noticing regressions in performance earlier with the latest Rust versions.